### PR TITLE
feat(staking): Exposing staking contracts lib

### DIFF
--- a/workspace/apps/staking/contracts/Scarb.toml
+++ b/workspace/apps/staking/contracts/Scarb.toml
@@ -13,6 +13,8 @@ contracts_commons = { path = "../../../packages/contracts" }
 [dev-dependencies]
 snforge_std.workspace = true
 
+[lib]
+
 [scripts]
 test = "snforge test"
 


### PR DESCRIPTION
Adding `[lib]` so anyone can import the staking package.