### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1179,7 +1179,7 @@ Add a new pool member to the delegation pool.
 Only a non-listed pool member address.
 #### logic <!-- omit from toc -->
 1. Transfer funds from pool member to pool contract.
-2. Approve transferal from pool contract to staking contract.
+2. Approve transfer from pool contract to staking contract.
 3. Call staking contract's [add_stake_from_pool](#add_stake_from_pool).
 4. Get current index from staking contract.
 5. Create entry for pool member.

--- a/workspace/apps/staking/L1/starkware/solidity/interfaces/ProxySupport.sol
+++ b/workspace/apps/staking/L1/starkware/solidity/interfaces/ProxySupport.sol
@@ -29,7 +29,7 @@ abstract contract ProxySupport is MGovernance, BlockDirectCall, ContractInitiali
       1. This function cannot be called directly on the deployed contract, but only via
          delegate call.
       2. If an EIC is provided - init is passed onto EIC and the standard init flow is skipped.
-         This true for both first intialization or a later one.
+         This true for both first initialization or a later one.
       3. The data passed to this function is as follows:
          [sub_contracts addresses, eic address, initData].
 

--- a/workspace/apps/staking/L1/starkware/solidity/libraries/RolesLib.sol
+++ b/workspace/apps/staking/L1/starkware/solidity/libraries/RolesLib.sol
@@ -94,7 +94,7 @@ library RolesLib {
         if (securityRolesInitialized()) {
             // If SecurityAdmin initialized,
             // then provisionalSecAdmin must already be a `SecurityAdmin`.
-            // If it's not initilized - initialize it.
+            // If it's not initialized - initialize it.
             require(
                 AccessControl.hasRole(SECURITY_ADMIN, provisionalSecAdmin),
                 "SECURITY_ROLES_ALREADY_INITIALIZED"

--- a/workspace/apps/staking/L1/starkware/solidity/stake/MintManager.sol
+++ b/workspace/apps/staking/L1/starkware/solidity/stake/MintManager.sol
@@ -109,7 +109,7 @@ contract MintManager is IMintManager, Identity, ProxySupportImpl, PeriodMintLimi
     }
 
     /**
-      Unegister an eligible token minter.
+      Unregister an eligible token minter.
       Callable only by the app governor or a security agent/admin.
     */
     function revokeTokenMinter(address token, address minter) external onlySecurityRole {


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `transferal` to `transfer`
Corrected `intialization` to `initialization`
Corrected `initilized` to `initialized`
Corrected ` Unegister` to `Unregister`

Please review the changes and let me know if any additional changes are needed.