### PR TITLE
docs: Fix grammar and spelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The project is built with [Turbo repo](https://turbo.build/) and [pnpm](https://
 Turbo's installation process will also install the cairo dependencies such as [Scarb](https://docs.swmansion.com/scarb/) and [Starknet foundry](https://foundry-rs.github.io/starknet-foundry/index.html).
 
 ## Installation
-Clone the repo and from within the projects root folder run:
+Clone the repo and from within the project's root folder run:
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 nvm install 20


### PR DESCRIPTION
### 1. Staknet's → Starknet's
**Explanation: This fixes a typo in the project name. "Starknet" is the correct name of the blockchain platform, while "Staknet" was a misspelling. Proper naming is crucial for technical documentation, especially when referring to specific platforms or technologies.**

### 2. build → built

**Explanation: This is a grammatical correction. In this context, we need the past participle form "built" because:
The sentence is in passive voice ("is built")
We're describing an existing state of the project
"build" is the present tense/base form, which is incorrect in passive voice constructions**

### 3. projects → project's

**Explanation: This is a correction of possessive form:
projects (without apostrophe) would indicate plural form (multiple projects)
project's (with apostrophe) correctly indicates possession (the root folder belongs to the project)
Since we're referring to a single project's root folder, we need the singular possessive form**