### PR TITLE
fix Update install-scarb.js

### DIFF
--- a/scripts/install-scarb.js
+++ b/scripts/install-scarb.js
@@ -13,7 +13,7 @@ try {
   );
 } catch {
   console.log('asdf already exists');
-  return;
+  process.exit(0);
 }
 
 process.env.PATH = `${process.env.PATH}:${asdfTargetDir}/bin:${asdfTargetDir}/shims`;


### PR DESCRIPTION
This PR fixes a critical syntax issue in the setup script where a `return` statement is used outside of any function block, which is not allowed in Node.js.

## Problem

In the following block:

```js
} catch {
  console.log('asdf already exists');
  return; //  SyntaxError: Illegal return statement
}

Using return outside of a function causes the script to crash with a SyntaxError.

Replaced the invalid return with a safe script termination using:

console.log('asdf already exists');
process.exit(0);

This need cuz:

Avoids script crash during setup

Ensures graceful exit if asdf already exists

Aligns with proper Node.js syntax rules